### PR TITLE
Update node engine for npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/roguelike-td/package-lock.json
+++ b/roguelike-td/package-lock.json
@@ -1,15 +1,21 @@
 {
   "name": "roguelike-td",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "roguelike-td",
+      "version": "0.0.0",
       "dependencies": {
-        "phaser": "^3.90.0"
+        "phaser": "^3.80.0"
       },
       "devDependencies": {
-        "typescript": "^5.9.2",
-        "vite": "^7.1.5"
+        "typescript": "~5.8.3",
+        "vite": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -982,9 +988,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
Resolve `EBADENGINE` warnings by updating `roguelike-td/package-lock.json` with correct Node.js engine requirements.

The `npm install` command was failing with `EBADENGINE` warnings due to a Node.js version mismatch (v18 vs required >=22.12.0). Node.js was upgraded to v22, and `npm install` was re-run, which updated the lockfile to include the `engines` field and resolve the dependency issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-eac08538-28dd-44a7-bdfa-9ed6a84cfdc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eac08538-28dd-44a7-bdfa-9ed6a84cfdc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

